### PR TITLE
feat: add argo workflow to udash-agent

### DIFF
--- a/charts/udash-agent/Chart.yaml
+++ b/charts/udash-agent/Chart.yaml
@@ -1,7 +1,8 @@
 apiVersion: v2
-appVersion: 0.86.1
+appVersion: 0.96.0
 description: Udash Agent, is the Updatecli DASHboard agent running Updatecli to check your repositories updates.
 icon: https://www.updatecli.io/images/updatecli_transparent.png
 name: udash-agent
 type: application
-version: 0.7.0
+version: 0.8.0
+

--- a/charts/udash-agent/templates/_helpers.tpl
+++ b/charts/udash-agent/templates/_helpers.tpl
@@ -77,3 +77,20 @@ Create the name of the secrets use by udash agents
 {{- define "udash.secretName" -}}
 {{- default (include "udash.fullname" .) .Values.secrets.name }}
 {{- end }}
+
+{{/*
+Get the first defined hostname
+*/}}
+{{- define "udash.host" -}}
+  {{- if and .Values.ingress .Values.ingress.hosts -}}
+    {{- $first := (index .Values.ingress.hosts 0) -}}
+    {{- if $first.host -}}
+      {{- $first.host -}}
+    {{- else -}}
+      {{- "" -}}
+    {{- end -}}
+  {{- else -}}
+    {{- "" -}}
+  {{- end -}}
+{{- end -}}
+

--- a/charts/udash-agent/templates/argoworkflow.yaml
+++ b/charts/udash-agent/templates/argoworkflow.yaml
@@ -1,0 +1,128 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: run-updatecli-diff
+spec:
+  entrypoint: main
+  arguments:
+    parameters:
+      - name: repo-url
+        description: GitHub repo to clone
+      - name: repo-branch
+        description: GitHub repo branch to clone
+        default: main
+      - name: updatecli-compose-file
+        description: the updatecli compose file
+        default: updatecli-compose.yaml
+  templates:
+    - name: main
+      volumes:
+        - name: workspace
+          emptyDir: {}
+      inputs:
+        parameters:
+          - name: repo-url
+          - name: repo-branch
+          - name: updatecli-compose-file
+      containerSet:
+        volumeMounts:
+          - mountPath: /workspace
+            name: workspace
+        containers:
+          - name: git-clone
+            image: alpine/git
+            command: [sh, -c]
+            args:
+              - |
+                git clone \
+                  --branch {{ "{{" }} inputs.parameters.repo-branch {{ "}}"}} \
+                  {{ "{{" }}inputs.parameters.repo-url{{ "}}" }} \
+                  /workspace
+
+          - name: updatecli
+            image: updatecli/updatecli:latest
+            dependencies:
+              - git-clone
+            command: [sh, -c]
+            env:
+            # {{- range $env, $value := $.Values.secrets.agent.environments }}
+              - name: "{{ $env }}"
+                valueFrom:
+                  secretKeyRef:
+                    name: '{{ include "udash.secretName" $ }}'
+                    key: "{{ $env }}"
+            # {{- end }}
+            args:
+              - |
+                cd /workspace
+                updatecli udash login --experimental --api-url http://agentrelay {{ default "agentrelay" (include "udash.host" . )}};
+                updatecli compose diff --experimental --file /workspace/{{ "{{" }} inputs.parameters.updatecli-compose-file {{ "}}" }};
+                updatecli udash logout --experimental {{ default "agentrelay " (include "udash.host" .)}};
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: updatecli-workflow-sa
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: updatecli-workflow-role
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "persistentvolumeclaims"]
+    verbs: ["create", "get", "watch", "list", "delete"]
+  - apiGroups: ["argoproj.io"]
+    resources: ["workflows"]
+    verbs: ["create", "get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
+  - apiGroups: ["argoproj.io"]
+    resources: ["workflowtaskresults","workflows"]
+    verbs: ["create", "get", "list", "watch", "patch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: updatecli-workflow-binding
+subjects:
+  - kind: ServiceAccount
+    name: updatecli-workflow-sa
+    namespace: udash
+roleRef:
+  kind: Role
+  name: updatecli-workflow-role
+  apiGroup: rbac.authorization.k8s.io
+
+#{{ range $workflow := .Values.workflows }}
+---
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: cron-run-updatecli-diff
+spec:
+  schedule: '{{ $workflow.schedule | default $.Values.defaultSchedule }}'
+  timezone: "UTC"
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  startingDeadlineSeconds: 0
+  workflowSpec:
+    workflowTemplateRef:
+      name: run-updatecli-diff
+    arguments:
+      parameters:
+        - name: repo-url
+          value: {{ $workflow.url }}
+        - name: repo-branch
+          value: {{ $workflow.branch }}
+        - name: updatecli-compose-file
+          value: {{ $workflow.composefile }}
+#{{ end }}

--- a/charts/udash-agent/values.yaml
+++ b/charts/udash-agent/values.yaml
@@ -165,3 +165,20 @@ defaultUdashConfig: |
 #        },
 #        "Default":"agentrelay"
 #      }
+#
+
+# workflows is a list of Updatecli compose files to run periodically via a cronjob.
+# it accepts a git repository url, a branch and a compose file.
+# For each scm, an argo workflow is created to run the Updatecli compose file.
+# workflows:
+#   - url: "https://github.com/updatecli/udash.git"
+#     branch: "main"
+#     composefile: "updatecli-compose.yaml"
+#   - url: "https://github.com/updatecli/releasepost.git"
+#     branch: "main"
+#     composefile: "updatecli-compose.yaml"
+
+#ingress:
+#  hosts:
+#    - host: testudash
+#  


### PR DESCRIPTION
## Description

Allows to use argo workflow to clone git repositories containing updatecli configuration.
At the moment it only handles public git repositories

## Test

To test this pull request, you can run the following commands:

```shell
helm lint charts/udash-agent
helm template charts/udash-agent  
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
